### PR TITLE
Updates package names, better template paths and correct repo url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,6 @@ foreman_admin_password: p3tj7WgwjOsx4v6HLu
 foreman_admin_first_name: Admin
 foreman_admin_last_name: Admin
 foreman_admin_email: "root@{{ ansible_domain }}"
-foreman_db_type: postgresql
 foreman_selinux: true
 foreman_passenger: true
 foreman_unattended: true

--- a/tasks/config/foreman.yml
+++ b/tasks/config/foreman.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: render /etc/foreman/settings.yaml
-  template: src=../../templates/settings.yml.j2 dest=/etc/foreman/settings.yaml owner=root group={{ foreman_group }} mode=0640
+  template: src=settings.yml.j2 dest=/etc/foreman/settings.yaml owner=root group={{ foreman_group }} mode=0640
   notify: restart apache
 
 - name: render /etc/sysconfig/foreman
-  template: src=../../templates/foreman.sysconfig.j2 dest=/etc/sysconfig/foreman mode=0644
+  template: src=foreman.sysconfig.j2 dest=/etc/sysconfig/foreman mode=0644
 
 - name: render foreman-proxy settings.d templates
   template: src={{ item }} dest=/etc/foreman/{{ item | basename | regex_replace('.j2','') }} owner=root group={{ foreman_group }} mode=0640

--- a/tasks/config/passenger.yml
+++ b/tasks/config/passenger.yml
@@ -8,5 +8,5 @@
   when: ansible_distribution_major_version == '7'
 
 - name: render apache vhost template
-  template: src=../../templates/apache.vhost.j2 dest=/etc/httpd/conf.d/05-foreman.conf
+  template: src=templates/apache.vhost.j2 dest=/etc/httpd/conf.d/05-foreman.conf
   notify: restart apache

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -26,10 +26,10 @@
 - name: install ruby193-rubygem-passenger-native package
   yum: name={{ item }} state=present
   with_items:
-   - ruby193-rubygem-passenger-native-libs
+   - ruby193-rubygem-passenger40-native-libs
    - rubygem-passenger-native
-   - ruby193-rubygem-passenger
-   - ruby193-rubygem-passenger-native
+   - ruby193-rubygem-passenger40
+   - ruby193-rubygem-passenger40-native
    - rubygem-passenger-native-libs
    - mod_passenger
    - rubygem-passenger

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,3 +1,3 @@
 ---
 foreman_repo_dist: f
-foreman_repo_os_rel: 19
+foreman_repo_os_rel: 24


### PR DESCRIPTION
As the title states this contains several fixes. The update of the package names is the most important one, the current master breaks when provisioning due that packages are not found. 

I also gave the Fedora repository a version bump as Foreman has done themselves: https://yum.theforeman.org/

I also edited the template paths to a more Ansible way where I could.

Hope everything is clear and although you seem to be working on a new setup for this role. Consider merging this fix because the master in current state is broken.